### PR TITLE
Fix logic error in evaluate() return statement

### DIFF
--- a/downstream/Antibody/in_silico/finetune_in_silico.py
+++ b/downstream/Antibody/in_silico/finetune_in_silico.py
@@ -249,7 +249,7 @@ def evaluate(model, loader, args):
         pearsons.append(pearson)
         spearmans.append(spearman)
 
-    return np.mean(mse), np.mean(pearson), np.mean(spearman)
+    return np.mean(mses), np.mean(pearsons), np.mean(spearmans)
 
 
 @torch.no_grad()
@@ -283,7 +283,7 @@ def train(model, train_loader, val_loader, cfg, args):
         eps=cfg.adam_eps,
         weight_decay=cfg.weight_decay,
     )
-    loss_fn = torch.nn.MSELoss()
+    loss_fn = torch.nn.Loss()
     model.to(device)
 
     for epoch in range(args.num_epochs):
@@ -311,7 +311,7 @@ def train(model, train_loader, val_loader, cfg, args):
 
         if epoch == args.num_epochs - 1:
             print(f"Evaluating at epoch {epoch}")
-            mse, pearson, spearman = evaluate(model, val_loader, args)
+            , pearson, spearman = evaluate(model, val_loader, args)
             print(mse, pearson, spearman)
             wandb.log(
                 {

--- a/downstream/Antibody/in_silico/finetune_in_silico.py
+++ b/downstream/Antibody/in_silico/finetune_in_silico.py
@@ -311,7 +311,7 @@ def train(model, train_loader, val_loader, cfg, args):
 
         if epoch == args.num_epochs - 1:
             print(f"Evaluating at epoch {epoch}")
-            , pearson, spearman = evaluate(model, val_loader, args)
+            mse, pearson, spearman = evaluate(model, val_loader, args)
             print(mse, pearson, spearman)
             wandb.log(
                 {

--- a/downstream/Antibody/in_silico/finetune_in_silico.py
+++ b/downstream/Antibody/in_silico/finetune_in_silico.py
@@ -283,7 +283,7 @@ def train(model, train_loader, val_loader, cfg, args):
         eps=cfg.adam_eps,
         weight_decay=cfg.weight_decay,
     )
-    loss_fn = torch.nn.Loss()
+    loss_fn = torch.nn.MSELoss()
     model.to(device)
 
     for epoch in range(args.num_epochs):


### PR DESCRIPTION
Hi, I found a minor logical bug in evaluate(). The current code returns the mean of the last iteration's scalar instead of the entire list of results. This PR fixes the variable names to return the correct averaged metrics across all targets.