### PR TITLE
Fix logic error in evaluate() return statement

### DIFF
--- a/downstream/Antibody/in_silico/finetune_in_silico.py
+++ b/downstream/Antibody/in_silico/finetune_in_silico.py
@@ -249,7 +249,7 @@ def evaluate(model, loader, args):
         pearsons.append(pearson)
         spearmans.append(spearman)
 
-    return np.mean(mse), np.mean(pearson), np.mean(spearman)
+    return np.mean(mses), np.mean(pearsons), np.mean(spearmans)
 
 
 @torch.no_grad()


### PR DESCRIPTION
Hi, I found a minor logical bug in evaluate(). The current code returns the mean of the last iteration's scalar instead of the entire list of results. This PR fixes the variable names to return the correct averaged metrics across all targets.