### PR TITLE
Fix: Unpickling error when loading provided checkpoint file

### DIFF
--- a/mint/helpers/extract.py
+++ b/mint/helpers/extract.py
@@ -92,7 +92,7 @@ class MINTWrapper(nn.Module):
             token_dropout=cfg.token_dropout,
             use_multimer=use_multimer,
         )
-        checkpoint = torch.load(checkpoint_path, map_location=device)
+        checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=False)
         if use_multimer:
             # remove 'model.' in keys
             new_checkpoint = OrderedDict(

--- a/train.py
+++ b/train.py
@@ -108,7 +108,7 @@ if (not args.no_multimer) and args.copy_weights:
 
 if args.validate:
     if args.ckpt:
-        ckpt = torch.load(args.ckpt)
+        ckpt = torch.load(args.ckpt, weights_only=False)
         model.load_state_dict(ckpt["state_dict"], strict=False)
     trainer.validate(model, val_loader)
 else:


### PR DESCRIPTION
### Description
Fixed UnpicklingError during model checkpoint loading (with provided checkpoint) when trying to reproduce the example.

### Error reproduction
Running this piece of code from the provided example gives the following error.
Weights were downloaded from [here](https://huggingface.co/varunullanat2012/mint/resolve/main/mint.ckpt).
```python
from mint.mint.helpers.extract import load_config, MINTWrapper

cfg = load_config("mint/data/esm2_t33_650M_UR50D.json") # model config
device = 'cuda' # GPU device
checkpoint_path = 'weights/mint.ckpt' # Where you stored the model checkpoint

phla_predictor = MINTWrapper(cfg, checkpoint_path, sep_chains=True, device=device)
phla_predictor.model.eval()
```
> UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
> 	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
> 	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
> 	WeightsUnpickler error: Unsupported global: GLOBAL argparse.Namespace was not an allowed global by default. Please use `torch.serialization.add_safe_globals([argparse.Namespace])` or the `torch.serialization.safe_globals([argparse.Namespace])` context manager to allowlist this global if you trust this class/function.